### PR TITLE
Add founder onboarding month 1 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,214 +1,24 @@
-# nrsgirls
+# NRSgirls.com — Founder Onboarding (Month 1)
 
-NRSgirls.com – monorepo for the DJ + performer live-streaming platform (web, API, infra, legal). Private, pre-launch. Contains dev/staging/prod env templates, CI/CD, and policy docs. © NRS Group of Fresno. All rights reserved.
+This repo contains the early scaffolding for a Chaturbate-class platform with our twist:
+- Only female performers
+- Two rooms per performer
+- A **global DJ audio bus** (live or pre-recorded) perfectly synced for all rooms
 
-## Quick Start
+## Where to start
+- 📘 Month 1 plan: [`/docs/onboarding/month-01/README.md`](docs/onboarding/month-01/README.md)
+- ✅ Best practices: [`/docs/best-practices/README.md`](docs/best-practices/README.md)
+- ☑️ Checklists (PRs, Security, Release): [`/docs/checklists`](docs/checklists)
 
-### Using Dev Container (Recommended)
+## Minimum dev stack
+- Node.js LTS + pnpm
+- TypeScript + React/Next.js
+- PostgreSQL + Prisma
+- Redis (presence/pub-sub)
+- Docker + GitHub Actions
 
-This repository includes a VS Code Dev Container configuration for a consistent development environment.
-
-#### Prerequisites
-- [Docker](https://www.docker.com/get-started)
-- [VS Code](https://code.visualstudio.com/)
-- [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-
-#### Steps
-1. Clone the repository
-2. Open in VS Code
-3. When prompted, click "Reopen in Container" (or press `F1` → "Remote-Containers: Reopen in Container")
-4. The container will build and run `setup.sh` automatically
-5. Set up environment variables (see below)
-
-### Local Setup (Without Container)
-
-#### Prerequisites
-- Node.js 18 or later
-- npm or yarn
-- Git
-
-#### Steps
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/NRSgirls-com/nrsgirls.git
-   cd nrsgirls
-   ```
-
-2. Run the setup script:
-   ```bash
-   bash nrsgirls-platform/scripts/setup.sh
-   ```
-
-3. Set up environment variables:
-   ```bash
-   cp .env.example .env
-   # Edit .env with your actual values
-   ```
-
-4. Set up frontend environment:
-   ```bash
-   cd frontend/nextjs
-   cp .env.example .env.local
-   # Edit .env.local with your Stripe keys
-   ```
-
-5. Install frontend dependencies:
-   ```bash
-   cd frontend/nextjs
-   npm install
-   ```
-
-6. Start the development server:
-   ```bash
-   npm run dev
-   ```
-
-7. Visit http://localhost:3000
-
-## Environment Variables
-
-### Root `.env`
-Contains platform-wide configuration:
-- `DATABASE_URL`: PostgreSQL connection string
-- `JWT_SECRET`: Secret for JWT token signing
-- `S3_ENDPOINT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`: Object storage credentials
-
-### Frontend `.env.local`
-Contains frontend-specific configuration:
-- `STRIPE_SECRET_KEY`: Stripe API secret key
-- `STRIPE_WEBHOOK_SECRET`: Stripe webhook signing secret
-
-**Important**: Never commit real secrets. Use `.env.example` files as templates.
-
-## Project Structure
-
-```
-nrsgirls/
-├── .devcontainer/          # VS Code Dev Container configuration
-├── .github/workflows/      # GitHub Actions CI/CD
-├── .vscode/                # VS Code workspace settings and tasks
-├── frontend/nextjs/        # Next.js frontend application
-├── nrsgirls-platform/      # Platform scaffold and documentation
-│   ├── backend/           # Backend API stubs
-│   ├── frontend/          # Frontend component stubs
-│   ├── scripts/           # Automation scripts
-│   ├── deployment/        # Docker and deployment configs
-│   └── docs/              # Technical specs and documentation
-├── docs/                   # Additional documentation
-│   └── DEPLOYMENT.md      # Production deployment guide
-├── env/                    # Environment configurations
-└── README.md              # This file
-```
-
-## Available Scripts
-
-Run these from the root directory:
-
-```bash
-# Setup: Install dependencies
-bash nrsgirls-platform/scripts/setup.sh
-
-# Frontend: Build
-bash nrsgirls-platform/scripts/build-frontend.sh
-
-# Lint and Test
-bash nrsgirls-platform/scripts/lint-test.sh
-
-# Deploy (Docker Compose)
-bash nrsgirls-platform/scripts/deploy.sh dev
-
-# Environment Check
-bash nrsgirls-platform/scripts/env-check.sh
-```
-
-Or use VS Code tasks (`Ctrl+Shift+B` or `Cmd+Shift+B`):
-- Setup: Run setup.sh
-- Frontend: Build
-- Frontend: Dev Server
-- Docker: Start Compose
-- Lint and Test
-
-## Development Workflow
-
-### Working with the Frontend
-
-1. Navigate to the frontend directory:
-   ```bash
-   cd frontend/nextjs
-   ```
-
-2. Start the development server:
-   ```bash
-   npm run dev
-   ```
-
-3. Make changes and test locally
-
-4. Build for production:
-   ```bash
-   npm run build
-   ```
-
-### Testing Stripe Integration
-
-1. Get your Stripe test API keys from [Stripe Dashboard](https://dashboard.stripe.com/test/apikeys)
-
-2. Install the Stripe CLI:
-   ```bash
-   # macOS
-   brew install stripe/stripe-cli/stripe
-   
-   # Other platforms: https://stripe.com/docs/stripe-cli#install
-   ```
-
-3. Forward webhooks to your local server:
-   ```bash
-   stripe listen --forward-to localhost:3000/api/webhook
-   ```
-
-4. Test checkout flow at http://localhost:3000/pricing
-
-5. Trigger webhook events:
-   ```bash
-   stripe trigger checkout.session.completed
-   ```
-
-## CI/CD
-
-This repository uses GitHub Actions for continuous integration:
-- **On push/PR**: Runs setup, lint, test, and build
-- **No automatic deployment**: All deployments are manual
-- See `.github/workflows/ci.yml` for configuration
-
-## Deployment
-
-For production deployment instructions, see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
-
-Recommended stack:
-- **Frontend**: Vercel
-- **API**: Render or Fly.io
-- **Database**: Supabase or Neon (PostgreSQL)
-- **Storage**: Cloudflare R2 or AWS S3
-- **Payments**: Stripe
-
-## Branch: nrsgirls-setup
-
-The `nrsgirls-setup` branch contains the reproducible developer environment setup, CI workflows, minimal Next.js frontend scaffold with Stripe integration, and deployment documentation. This branch is under review via pull request.
-
-To test this setup:
-1. Checkout the `nrsgirls-setup` branch
-2. Follow the Quick Start instructions above
-3. Test the frontend and Stripe integration locally
-
-## Contributing
-
-This is a private repository. For internal team members:
-1. Create a feature branch from `main`
-2. Make your changes
-3. Run lint and tests locally
-4. Create a pull request for review
-5. After approval, merge to `main`
-
-## License
-
-© NRS Group of Fresno. All rights reserved. Private, proprietary software.
+## Project goals (M1)
+- Learn HTML/CSS + TypeScript fundamentals
+- Build landing + auth screens in Next.js
+- Stand up Postgres + Prisma with Users/Performers/Rooms
+- Add WebSocket presence baseline

--- a/docs/best-practices/README.md
+++ b/docs/best-practices/README.md
@@ -1,0 +1,45 @@
+# Best Practices (Month 1)
+
+## Editor
+- Save on format; ESLint fixes on save
+- One concept per commit; small PRs
+
+## Git
+- Branch: `feat/<area>`, `fix/<area>`, `docs/<area>`
+- Conventional commits; rebase small PRs
+- PR template: summary, screenshots, test notes
+
+## TypeScript
+- `"strict": true`
+- Never `any` in app code
+- Types for API inputs/outputs (Zod schemas)
+
+## React/Next.js
+- Server components by default
+- Client components only when needed (state, effects)
+- Use `app/` router; colocate components per route
+- Avoid prop drilling; lightweight stores (Zustand)
+
+## Styling
+- Tailwind for 90% of styles; extract components when repeated
+- Accessible components: labels, roles, focus states
+
+## Data
+- Prisma migrations in PRs
+- Use UUID/CUID ids
+- Soft deletes only if required; otherwise archive table
+
+## Security (Month 1 scope)
+- Never commit secrets; use `.env.local` examples
+- Rate-limit public endpoints
+- Validate every request (Zod)
+- HTTPS everywhere in prod
+
+## Presence & Realtime
+- WebSocket events: small, versioned payloads
+- Backpressure: drop noisy events; debounce room state
+
+## WebRTC (intro)
+- Separate signalling from media logic
+- Handle `ICE` candidates robustly
+- Plan for TURN early (budget line)

--- a/docs/checklists/pr-review.md
+++ b/docs/checklists/pr-review.md
@@ -1,0 +1,7 @@
+# PR Review — Quick Checks
+- Scope small, clear title
+- Lints pass, tests pass
+- No secrets in diff
+- Types strict; no `any`
+- Routing ok; API input validated
+- Screenshots or console output for changes

--- a/docs/checklists/release.md
+++ b/docs/checklists/release.md
@@ -1,0 +1,6 @@
+# Release — Month 1
+- Migrations applied
+- Seed runs without error
+- Landing + Auth render
+- Presence toggles room live status
+- Basic WebRTC lab page loads, no console errors

--- a/docs/checklists/security.md
+++ b/docs/checklists/security.md
@@ -1,0 +1,7 @@
+# Security — Month 1
+- .env templates present; real secrets excluded
+- HTTPS in dev proxy (optional), required in prod
+- Rate limit auth and public routes
+- Input validation (Zod) on all endpoints
+- DB least privilege: separate `app` user
+- Audit basic access logs enabled

--- a/docs/onboarding/month-01/README.md
+++ b/docs/onboarding/month-01/README.md
@@ -1,0 +1,52 @@
+# Month 1 – Founder Curriculum (Hands-On)
+
+> Aim: become fluent enough to read/lead code reviews, ship a landing page + auth, set DB + presence, and understand WebRTC basics.
+
+## What you’ll learn
+- HTML, CSS (Tailwind), TypeScript essentials
+- Next.js file routing, server actions, API routes
+- Postgres + Prisma data modeling
+- WebSocket presence (who’s live / which room)
+- WebRTC mental model (offer/answer, ICE, STUN/TURN)
+
+## Weekly plan
+- Week 1 — HTML/CSS + TS warm-up, VS Code setup
+- Week 2 — Next.js pages, auth flow, RBAC shells
+- Week 3 — Postgres + Prisma, seed data, presence
+- Week 4 — WebRTC concepts + baseline signalling stub
+
+## Repo conventions (Month 1)
+- Package manager: **pnpm**
+- Code style: ESLint + Prettier (`"semi": false`, `"singleQuote": true`)
+- Paths:
+  - App: `/app` (Next.js app router)
+  - API routes: `/app/api/*`
+  - DB schema: `/prisma/schema.prisma`
+  - Docs: `/docs/*`
+
+## Daily rhythm (Mon–Fri)
+- 90 min learn → 90 min build → 30 min notes → 30 min cleanup
+- Commit messages: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`
+
+## Install (local)
+```bash
+# Node & pnpm
+node -v
+corepack enable
+pnpm -v
+
+# Install deps
+pnpm i
+
+# Dev env
+cp .env.example .env.local
+pnpm dev
+```
+
+## Milestones (Month 1)
+
+* M1-01: Landing page (Tailwind), responsive
+* M1-02: Auth form + email login stub
+* M1-03: DB up with Prisma migrations (Users, Performers, Rooms)
+* M1-04: Presence (Redis/WebSocket) — “Room A/B live”
+* M1-05: WebRTC demo page (local cam preview + signalling stub)

--- a/docs/onboarding/month-01/week-01.md
+++ b/docs/onboarding/month-01/week-01.md
@@ -1,0 +1,46 @@
+# Week 1 – HTML/CSS/TS + Editor Setup
+
+## Outcomes
+- HTML semantics; responsive layout with Tailwind
+- TypeScript basics (types, interfaces, generics, async/await)
+- VS Code configured for speed and consistency
+
+## VS Code baseline
+Extensions:
+- ESLint
+- Prettier
+- Tailwind CSS IntelliSense
+- Error Lens
+- GitLens
+- Thunder Client (or Postman)
+- Prisma
+- YAML
+
+Settings (place in `.vscode/settings.json`):
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": "always" },
+  "files.eol": "\n",
+  "typescript.tsdk": "node_modules/typescript/lib"
+}
+```
+
+## Day plan
+
+**Day 1:** HTML structure, Flex/Grid, semantic tags
+**Day 2:** Tailwind utilities, responsive navbar/hero/footer
+**Day 3:** TypeScript intro + strict mode, functions + generics
+**Day 4:** Fetch in TS, basic API call in a Next.js route handler
+**Day 5:** Build a landing page from scratch (mobile-first)
+
+## Lab: Landing page
+
+* Hero, value props, CTA → `/app/page.tsx`
+* Footer with social placeholders
+* Mobile-first, then tablet/desktop
+
+## Success criteria
+
+* Lighthouse ≥ 90 (Perf/Access/SEO/Best Practices)
+* No ESLint errors; Prettier clean

--- a/docs/onboarding/month-01/week-02.md
+++ b/docs/onboarding/month-01/week-02.md
@@ -1,0 +1,19 @@
+# Week 2 – Next.js App + Auth Shell
+
+## Outcomes
+- App Router basics, layouts, metadata
+- Auth screens (UI), role shells (performer/mod/admin)
+
+## Tasks
+- Create `/app/(public)/login/page.tsx` and `/app/(public)/signup/page.tsx`
+- Add `/app/(dashboard)/performer/page.tsx` and `/app/(dashboard)/admin/page.tsx`
+- Create API route stub: `/app/api/auth/login/route.ts`
+- Client form with Zod validation (email, password)
+
+## RBAC (shell only)
+- Roles: user, performer, admin
+- Protect dashboard routes (temporary stub guard)
+
+## Success criteria
+- Can navigate public → dashboard routes
+- Form validation works; errors render in UI

--- a/docs/onboarding/month-01/week-03.md
+++ b/docs/onboarding/month-01/week-03.md
@@ -1,0 +1,48 @@
+# Week 3 – Database + Presence
+
+## Outcomes
+- Postgres + Prisma
+- Models: User, Performer, Room (A/B)
+- Presence via Redis + WebSocket
+
+## Prisma schema (start)
+```prisma
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  role      Role     @default(USER)
+  createdAt DateTime @default(now())
+}
+
+model Performer {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  rooms     Room[]
+  createdAt DateTime @default(now())
+}
+
+model Room {
+  id           String   @id @default(cuid())
+  performerId  String
+  name         String   // "Room A" | "Room B"
+  isLive       Boolean  @default(false)
+  updatedAt    DateTime @updatedAt
+}
+
+enum Role {
+  USER
+  PERFORMER
+  ADMIN
+}
+```
+
+## Presence (baseline)
+
+* `ws://…/api/ws` channel
+* Events: `JOIN_ROOM`, `LEAVE_ROOM`, `ROOM_STATUS`
+* Redis pub/sub to fan out room status
+
+## Success criteria
+
+* Migrations run; seed creates 1 performer with two rooms
+* Toggle “Room A/B live” and broadcast to clients

--- a/docs/onboarding/month-01/week-04.md
+++ b/docs/onboarding/month-01/week-04.md
@@ -1,0 +1,20 @@
+# Week 4 – WebRTC Fundamentals (Founder Level)
+
+## Outcomes
+- Understand offer/answer, ICE, STUN/TURN
+- Build a signalling stub (WebSocket)
+- Local preview page for testing
+
+## Pages
+- `/app/webrtc/lab/page.tsx`: Start/Stop cam, render `<video>` local
+- Signalling stub: `/app/api/signalling/route.ts` with WS upgrade
+- Messages: `OFFER`, `ANSWER`, `ICE`, `PING`
+
+## Reading goals (short)
+- What signalling is (and is not)
+- Why TURN is needed behind strict NATs
+- Why we’ll start with a dedicated **DJ audio bus** (single track)
+
+## Success criteria
+- You can describe SDP at a high level
+- You can send/receive a JSON `OFFER` and respond with `ANSWER` (loopback ok)


### PR DESCRIPTION
## Summary
- replace the root README with a month-one founder onboarding overview and key links
- add detailed month-one onboarding curriculum with weekly breakdowns
- document month-one best practices plus PR review, security, and release checklists

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e49ed5cd0c83308fd07affdb2335a3

## Summary by Sourcery

Provide comprehensive founder onboarding documentation for Month 1, replacing the existing root README with an overview of the Month 1 curriculum, development stack, and project goals, and adding detailed weekly guides, best practices, and operational checklists.

Documentation:
- Replace root README with a Month 1 founder onboarding overview including key links, dev stack, and goals
- Add detailed Month 1 curriculum under docs/onboarding/month-01 with weekly breakdowns (Weeks 1–4)
- Introduce a Month 1 best practices guide for code style, Git workflow, security, and realtime strategies
- Add PR review, security, and release checklists under docs/checklists for Month 1 readiness