### PR TITLE
Add repository structure guide and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo contains the early scaffolding for a Chaturbate-class platform with ou
 - 📘 Month 1 plan: [`/docs/onboarding/month-01/README.md`](docs/onboarding/month-01/README.md)
 - ✅ Best practices: [`/docs/best-practices/README.md`](docs/best-practices/README.md)
 - ☑️ Checklists (PRs, Security, Release): [`/docs/checklists`](docs/checklists)
+- 🧭 Repo structure map: [`/docs/repo-structure.md`](docs/repo-structure.md)
 
 ## Minimum dev stack
 - Node.js LTS + pnpm

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -1,0 +1,21 @@
+# Repository structure
+
+This repo contains a few top-level workspaces and reference documents. Use this map to locate where each element lives.
+
+## Top-level map
+
+- `docs/`: Primary documentation hub, including onboarding plans, best practices, and checklists.
+- `frontend/`: Early Next.js prototype work (currently a `nextjs/` starter).
+- `nrsgirls-platform/`: The main platform scaffold with backend, frontend, docs, and deployment assets.
+- `env/`: Environment configuration and local setup helpers.
+- `webhook-server.js`: Lightweight webhook listener used during development.
+- `dummy_commit.txt`: Placeholder file used for scaffolding tests.
+
+## Platform scaffold map (`nrsgirls-platform/`)
+
+- `nrsgirls-platform/docs/`: Vision, technical specs, legal memo, and business plan.
+- `nrsgirls-platform/frontend/`: Homepage plus DJ/performer portals and shared components.
+- `nrsgirls-platform/backend/`: API stubs, database schema notes, and integration references.
+- `nrsgirls-platform/brand-assets/`: Placeholder directories for logos/colors and the style guide.
+- `nrsgirls-platform/deployment/`: Docker, hosting configuration, and infrastructure notes.
+- `nrsgirls-platform/scripts/`: Setup and deployment automation helpers.

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -4,8 +4,13 @@ This repo contains a few top-level workspaces and reference documents. Use this 
 
 ## Top-level map
 
-- `docs/`: Primary documentation hub, including onboarding plans, best practices, and checklists.
+- `docs/`: Primary documentation hub for onboarding and operational guidance.
+  - `docs/onboarding/`: Month-by-month onboarding plans.
+  - `docs/best-practices/`: Engineering best practices and standards.
+  - `docs/checklists/`: PR, security, and release checklists.
+  - `docs/DEPLOYMENT.md`: High-level deployment notes.
 - `frontend/`: Early Next.js prototype work (currently a `nextjs/` starter).
+  - `frontend/nextjs/`: Experimental UI prototype.
 - `nrsgirls-platform/`: The main platform scaffold with backend, frontend, docs, and deployment assets.
 - `env/`: Environment configuration and local setup helpers.
 - `webhook-server.js`: Lightweight webhook listener used during development.


### PR DESCRIPTION
### Motivation
- Provide a simple navigational map so contributors can quickly locate top-level workspaces and key platform assets.
- Reduce onboarding friction by documenting where docs, frontend, backend, and deployment artifacts live. 

### Description
- Add `docs/repo-structure.md` that maps the repository top-level layout and the `nrsgirls-platform/` scaffold contents. 
- Link the new structure map from the root `README.md` under the "Where to start" section. 
- Content is documentation-only and contains no code or configuration changes. 

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1ba199388330ac607cebeb1d4866)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a concise map of the repository to aid contributor onboarding and navigation.
> 
> - Adds `docs/repo-structure.md` detailing top-level workspaces and the `nrsgirls-platform/` scaffold
> - Updates `README.md` "Where to start" with a link to `docs/repo-structure.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bab3cbb7af4bbc574cc3e05d08b9014bd116235d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Document the repository layout and link the new structure guide from the main README to improve contributor navigation.

Documentation:
- Add a repo structure guide detailing top-level directories and the nrsgirls-platform scaffold layout.
- Update the README "Where to start" section to link to the new repository structure guide.