### PR TITLE
docs: add Git configuration guide, fix paths, and clean up READMEs 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig — consistent coding styles across editors and IDEs
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.py]
+indent_size = 4
+
+[*.sh]
+indent_size = 2
+
+[*.sql]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,50 @@
+# Auto-detect text files and normalise line endings to LF on commit
+* text=auto eol=lf
+
+# Explicitly declare text files
+*.js     text eol=lf
+*.jsx    text eol=lf
+*.ts     text eol=lf
+*.tsx    text eol=lf
+*.json   text eol=lf
+*.css    text eol=lf
+*.scss   text eol=lf
+*.html   text eol=lf
+*.md     text eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.sh     text eol=lf
+*.sql    text eol=lf
+*.prisma text eol=lf
+*.env*   text eol=lf
+*.toml   text eol=lf
+
+# Docker
+Dockerfile text eol=lf
+docker-compose*.yml text eol=lf
+
+# Git config
+.gitattributes text eol=lf
+.gitignore     text eol=lf
+
+# Denote binary files that should not be modified
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.svg  binary
+*.woff binary
+*.woff2 binary
+*.ttf  binary
+*.eot  binary
+*.mp3  binary
+*.mp4  binary
+*.webm binary
+*.zip  binary
+*.tar.gz binary
+
+# Improve diff output for common web files
+*.css  diff=css
+*.html diff=html
+*.md   diff=markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '18'
           cache: 'yarn'
           cache-dependency-path: |
-            frontend/nextjs/yarn.lock
+            nrsgirls-platform/frontend/yarn.lock
 
       - name: Enable Corepack
         run: |
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install frontend dependencies
         run: |
-          if [ -d "frontend/nextjs" ] && [ -f "frontend/nextjs/package.json" ]; then
-            cd frontend/nextjs
+          if [ -d "nrsgirls-platform/frontend" ] && [ -f "nrsgirls-platform/frontend/package.json" ]; then
+            cd nrsgirls-platform/frontend
             yarn install --frozen-lockfile
           fi
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build frontend
         run: |
-          if [ -d "frontend/nextjs" ] && [ -f "frontend/nextjs/package.json" ]; then
-            cd frontend/nextjs
+          if [ -d "nrsgirls-platform/frontend" ] && [ -f "nrsgirls-platform/frontend/package.json" ]; then
+            cd nrsgirls-platform/frontend
             yarn build
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,53 @@
+# Dependencies
 node_modules/
+
+# Environment files
 .env
 .env.local
 .env.*.local
+
+# Build output
 /dist
 /build
-.DS_Store
-.idea/
-coverage/
-logs/
-*.log
 .next/
 out/
 *.tsbuildinfo
+
+# Vercel
 .vercel
+
+# OS files
+.DS_Store
+._*
+Thumbs.db
+Desktop.ini
+
+# Editor directories and files
+.idea/
+*.swp
+*.swo
+*~
+*.sublime-workspace
+*.sublime-project
+
+# Test coverage
+coverage/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Docker
+docker-compose.override.yml
+
+# Prisma
+prisma/*.db
+prisma/*.db-journal
+
+# Temporary files
+tmp/
+temp/
+*.tmp

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,7 @@
     {
       "label": "Frontend: Dev Server",
       "type": "shell",
-      "command": "cd frontend/nextjs && npm run dev",
+      "command": "cd nrsgirls-platform/frontend && yarn dev",
       "problemMatcher": [],
       "isBackground": true
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,25 +16,26 @@ NRSgirls is a DJ and performer streaming platform with privacy-first features. T
 
 ```
 nrsgirls/
-├── frontend/nextjs/          # Main Next.js frontend application
-│   ├── pages/                # Next.js pages (index, pricing, account, API routes)
-│   ├── styles/               # Global CSS styles
-│   └── .env.example          # Frontend environment template
 ├── nrsgirls-platform/        # Platform scaffolding and documentation
 │   ├── docs/                 # Vision, technical specs, legal, business plan
-│   ├── frontend/             # Additional frontend portals (DJ, performer, homepage)
-│   │   └── shared-components/# Shared React UI components (@nrsgirls/shared-components)
+│   ├── frontend/             # Next.js frontend application
+│   │   ├── pages/            # Next.js pages (index, pricing, account, API routes)
+│   │   ├── styles/           # Global CSS styles
+│   │   ├── shared-components/# Shared React UI components (@nrsgirls/shared-components)
+│   │   └── .env.example      # Frontend environment template
 │   ├── backend/              # API, database, security, streaming stubs
 │   ├── brand-assets/         # Logos, color schemes, style guide
 │   ├── deployment/           # Docker and infrastructure configs
 │   └── scripts/              # Setup, deployment, and utility scripts
 ├── docs/                     # Developer documentation
 │   ├── onboarding/           # Month-by-month onboarding guides
-│   ├── best-practices/       # Coding standards and conventions
+│   ├── best-practices/       # Coding standards, Git configuration
 │   ├── checklists/           # PR review, security, release checklists
 │   └── tech-updates/         # Framework upgrade notes (e.g., Next.js 16)
 ├── env/                      # Environment-specific configs (dev, staging, prod)
 ├── .github/workflows/        # CI/CD pipelines
+├── .gitattributes            # Line ending and diff settings
+├── .editorconfig             # Editor consistency settings
 └── vercel.json               # Vercel deployment configuration
 ```
 
@@ -68,7 +69,7 @@ cd nrsgirls
 bash nrsgirls-platform/scripts/setup.sh
 
 # Install frontend dependencies
-cd frontend/nextjs
+cd nrsgirls-platform/frontend
 yarn install
 
 # Copy environment file and configure
@@ -90,7 +91,7 @@ S3_ACCESS_KEY=replace-me
 S3_SECRET_KEY=replace-me
 ```
 
-**Frontend** (`frontend/nextjs/.env.local`):
+**Frontend** (`nrsgirls-platform/frontend/.env.local`):
 ```
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
@@ -98,7 +99,7 @@ STRIPE_WEBHOOK_SECRET=whsec_xxx
 
 ## Key Commands
 
-### Frontend (from `frontend/nextjs/`)
+### Frontend (from `nrsgirls-platform/frontend/`)
 ```bash
 yarn dev          # Start development server
 yarn build        # Production build
@@ -131,6 +132,11 @@ docker-compose down     # Stop all services
 - Use conventional commits
 - Keep PRs small and focused
 
+### Git Configuration
+- See `docs/best-practices/git-configuration.md` for recommended Git settings
+- `.gitattributes` enforces LF line endings across platforms
+- `.editorconfig` ensures consistent editor behavior
+
 ### TypeScript
 - Enable `"strict": true` in tsconfig
 - Never use `any` in application code
@@ -159,7 +165,7 @@ docker-compose down     # Stop all services
 Testing is still being set up. When available:
 
 ```bash
-# Run from frontend/nextjs
+# Run from nrsgirls-platform/frontend
 yarn test
 
 # Or use the lint-test script
@@ -183,7 +189,7 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on all pushes:
 
 ### Vercel (Frontend)
 - Auto-deploys from main branch
-- Root directory: `frontend/nextjs`
+- Root directory: `nrsgirls-platform/frontend`
 - Build command: `yarn install && yarn build`
 - Configure environment variables in Vercel dashboard
 
@@ -198,11 +204,14 @@ See `docs/DEPLOYMENT.md` for detailed deployment instructions.
 
 | File | Purpose |
 |------|---------|
-| `vercel.json` | Vercel deployment config (root: `frontend/nextjs`) |
+| `vercel.json` | Vercel deployment config (root: `nrsgirls-platform/frontend`) |
 | `.github/workflows/ci.yml` | CI pipeline definition |
-| `frontend/nextjs/pages/api/webhook.js` | Stripe webhook handler |
-| `frontend/nextjs/pages/api/checkout.js` | Stripe checkout API |
+| `.gitattributes` | Line ending normalization rules |
+| `.editorconfig` | Cross-editor consistency settings |
+| `nrsgirls-platform/frontend/pages/api/webhook.js` | Stripe webhook handler |
+| `nrsgirls-platform/frontend/pages/api/checkout.js` | Stripe checkout API |
 | `docs/best-practices/README.md` | Coding standards |
+| `docs/best-practices/git-configuration.md` | Git configuration guide |
 | `docs/checklists/pr-review.md` | PR review checklist |
 | `docs/checklists/security.md` | Security checklist |
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,120 @@
-# NRSgirls.com — Founder Onboarding (Month 1)
+# NRSgirls.com
 
-This repo contains the early scaffolding for a Chaturbate-class platform with our twist:
-- Only female performers
+A DJ and performer streaming platform with privacy-first features, connecting DJs and performers while preserving performer privacy and legal safety.
+
+## Key Features
+
+- DJ enrollment, dashboard, and mix uploads
+- Performer profiles with privacy controls
+- Global DJ audio bus (live or pre-recorded) synced across rooms
 - Two rooms per performer
-- A **global DJ audio bus** (live or pre-recorded) perfectly synced for all rooms
+- Streaming with CDN-backed delivery
 
-## Where to start
-- 📘 Month 1 plan: [`/docs/onboarding/month-01/README.md`](docs/onboarding/month-01/README.md)
-- ✅ Best practices: [`/docs/best-practices/README.md`](docs/best-practices/README.md)
-- ☑️ Checklists (PRs, Security, Release): [`/docs/checklists`](docs/checklists)
-- 🔄 Next.js 16 upgrade notes: [`/docs/tech-updates/nextjs16-upgrade.md`](docs/tech-updates/nextjs16-upgrade.md)
+## Repository Structure
 
-## Minimum dev stack
-- Node.js LTS + pnpm
-- TypeScript + React/Next.js
-- PostgreSQL + Prisma
-- Redis (presence/pub-sub)
-- Docker + GitHub Actions
+```
+nrsgirls/
+├── nrsgirls-platform/        # Platform code and documentation
+│   ├── docs/                 # Vision, technical specs, legal, business plan
+│   ├── frontend/             # Next.js app, portals, shared components
+│   ├── backend/              # API, database, security, streaming stubs
+│   ├── brand-assets/         # Logos, color schemes, style guide
+│   ├── deployment/           # Docker and infrastructure configs
+│   └── scripts/              # Setup, deployment, and utility scripts
+├── docs/                     # Developer documentation
+│   ├── onboarding/           # Month-by-month onboarding guides
+│   ├── best-practices/       # Coding standards, Git configuration
+│   ├── checklists/           # PR review, security, release checklists
+│   └── tech-updates/         # Framework upgrade notes
+├── .github/workflows/        # CI/CD pipelines
+├── .gitattributes            # Line ending and diff settings
+├── .editorconfig             # Editor consistency settings
+└── vercel.json               # Vercel deployment configuration
+```
 
-## Project goals (M1)
+## Quick Start
+
+```bash
+# Clone
+git clone <repo-url> && cd nrsgirls
+
+# Run setup
+bash nrsgirls-platform/scripts/setup.sh
+
+# Install frontend dependencies
+cd nrsgirls-platform/frontend
+yarn install
+
+# Configure environment
+cp .env.example .env.local
+# Edit .env.local with your Stripe keys
+
+# Start dev server
+yarn dev
+```
+
+## Tech Stack
+
+| Layer        | Technology                             |
+|--------------|----------------------------------------|
+| Frontend     | Next.js 13.5, React 18, TypeScript    |
+| Backend      | Node.js 18+ (Express or FastAPI)       |
+| Database     | PostgreSQL 15 with Prisma ORM          |
+| Cache/PubSub | Redis                                 |
+| Payments     | Stripe                                 |
+| Storage      | S3-compatible (Cloudflare R2 / AWS)    |
+| Deployment   | Vercel (frontend), Render/Fly.io (API) |
+| CI/CD        | GitHub Actions                         |
+
+## Git Configuration
+
+All contributors should configure Git for this project. See the full guide:
+
+**[Git Configuration Guide](docs/best-practices/git-configuration.md)**
+
+Essential settings:
+
+```bash
+# Line endings (macOS/Linux)
+git config --global core.autocrlf input
+
+# Rebase on pull for linear history
+git config --global pull.rebase true
+
+# Better merge conflict display
+git config --global merge.conflictstyle diff3
+```
+
+The repo includes `.gitattributes` for automatic line-ending normalization and `.editorconfig` for consistent editor behavior.
+
+### Branching Convention
+
+- `feat/<area>` -- new features
+- `fix/<area>` -- bug fixes
+- `docs/<area>` -- documentation
+- Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Onboarding (Month 1)](docs/onboarding/month-01/README.md) | Week-by-week learning plan |
+| [Best Practices](docs/best-practices/README.md) | Coding standards and conventions |
+| [Git Configuration](docs/best-practices/git-configuration.md) | Git setup for contributors |
+| [PR Review Checklist](docs/checklists/pr-review.md) | Code review quick checks |
+| [Security Checklist](docs/checklists/security.md) | Security baseline |
+| [Release Checklist](docs/checklists/release.md) | Release readiness |
+| [Deployment Guide](docs/DEPLOYMENT.md) | Step-by-step deployment |
+| [Next.js 16 Upgrade](docs/tech-updates/nextjs16-upgrade.md) | Framework upgrade notes |
+
+## Month 1 Goals
+
 - Learn HTML/CSS + TypeScript fundamentals
 - Build landing + auth screens in Next.js
 - Stand up Postgres + Prisma with Users/Performers/Rooms
 - Add WebSocket presence baseline
+- Understand WebRTC basics (offer/answer, ICE, STUN/TURN)
+
+## License
+
+Proprietary. All rights reserved.

--- a/docs/best-practices/README.md
+++ b/docs/best-practices/README.md
@@ -8,6 +8,7 @@
 - Branch: `feat/<area>`, `fix/<area>`, `docs/<area>`
 - Conventional commits; rebase small PRs
 - PR template: summary, screenshots, test notes
+- See [Git Configuration Guide](git-configuration.md) for recommended settings
 
 ## TypeScript
 - `"strict": true`

--- a/docs/best-practices/git-configuration.md
+++ b/docs/best-practices/git-configuration.md
@@ -1,0 +1,159 @@
+# Git Configuration Guide
+
+Recommended Git configuration for all NRSgirls contributors. Run these commands after cloning the repository to ensure a consistent development experience.
+
+## Required Setup
+
+```bash
+# Identity (use your real name and GitHub email)
+git config user.name "Your Name"
+git config user.email "you@example.com"
+
+# Default branch name
+git config init.defaultBranch main
+```
+
+## Recommended Client Settings
+
+```bash
+# Editor — set to your preferred editor
+git config --global core.editor "code --wait"   # VS Code
+# git config --global core.editor "vim"          # Vim
+# git config --global core.editor "nano"         # Nano
+
+# Pager — use less with better defaults
+git config --global core.pager "less -FRX"
+
+# Auto-correct mistyped commands after 1.5 seconds
+git config --global help.autocorrect 15
+
+# Colorized output
+git config --global color.ui auto
+```
+
+## Line Endings
+
+Cross-platform consistency is critical. The `.gitattributes` file at the repo root enforces line-ending rules, but set your local config as a safety net:
+
+```bash
+# macOS / Linux — convert CRLF to LF on commit, no conversion on checkout
+git config --global core.autocrlf input
+
+# Windows — convert LF to CRLF on checkout, CRLF to LF on commit
+git config --global core.autocrlf true
+```
+
+## Whitespace
+
+```bash
+# Detect trailing whitespace, blank lines at EOF, and spaces before tabs
+git config --global core.whitespace trailing-space,blank-at-eof,space-before-tab
+```
+
+## Merge and Diff
+
+```bash
+# Show common ancestor in merge conflicts (makes conflicts easier to read)
+git config --global merge.conflictstyle diff3
+
+# Reuse recorded resolution — Git remembers how you resolved a conflict
+git config --global rerere.enabled true
+```
+
+## Pull Strategy
+
+```bash
+# Default to rebase on pull to keep a linear history
+git config --global pull.rebase true
+```
+
+## Commit Signing (Optional)
+
+If you have a GPG key, sign your commits:
+
+```bash
+git config --global user.signingkey <your-gpg-key-id>
+git config --global commit.gpgsign true
+```
+
+## Global Gitignore
+
+Create a personal global gitignore so OS and editor files never pollute the repo:
+
+```bash
+# Create the file
+cat > ~/.gitignore_global << 'EOF'
+# macOS
+.DS_Store
+._*
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# Editors
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.sublime-workspace
+
+# Environment
+.env.local
+.env.*.local
+EOF
+
+# Tell Git to use it
+git config --global core.excludesfile ~/.gitignore_global
+```
+
+## Commit Message Template
+
+Use the project commit template for consistent messages:
+
+```bash
+git config commit.template .gitmessage
+```
+
+If the template file does not yet exist, create `.gitmessage` in the repo root:
+
+```
+<type>: <subject>
+
+# Types: feat, fix, docs, chore, refactor, test, style, perf
+# Subject: imperative mood, no period, under 50 chars
+#
+# Body (optional): explain *why*, not *what*
+#
+# Footer (optional): references, breaking changes
+# Refs: #123
+```
+
+## Aliases (Optional Productivity Boosters)
+
+```bash
+git config --global alias.st status
+git config --global alias.co checkout
+git config --global alias.br branch
+git config --global alias.ci commit
+git config --global alias.lg "log --oneline --graph --decorate --all"
+git config --global alias.last "log -1 HEAD --stat"
+git config --global alias.unstage "reset HEAD --"
+```
+
+## Verifying Your Configuration
+
+```bash
+# Show all effective settings and where they come from
+git config --list --show-origin
+
+# Check a specific value
+git config user.name
+git config core.autocrlf
+```
+
+## Further Reading
+
+- [Git Documentation — git-config](https://git-scm.com/docs/git-config)
+- [Pro Git Book — Customizing Git](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)

--- a/docs/tech-updates/nextjs16-upgrade.md
+++ b/docs/tech-updates/nextjs16-upgrade.md
@@ -30,7 +30,7 @@
 - `unstable_rootParams`, experimental PPR flags, and next/legacy/image are removed/deprecated.
 
 ## Repo-specific to-dos
-- [ ] Confirm `frontend/nextjs` uses Node 20.9+ in CI/local and TypeScript 5.1+.
+- [ ] Confirm `nrsgirls-platform/frontend` uses Node 20.9+ in CI/local and TypeScript 5.1+.
 - [ ] If we still have `middleware.ts`, rename to `proxy.ts` and update the export.
 - [ ] Audit API routes/pages for single-argument `revalidateTag` calls; add a cacheLife profile or switch to `updateTag`/`refresh` in Server Actions.
 - [ ] Enable `cacheComponents` once we validate cache key strategy for our pages.

--- a/dummy_commit.txt
+++ b/dummy_commit.txt
@@ -1,5 +1,0 @@
-# Dummy commit to trigger redeployment
-
-This commit is intended to trigger a redeployment on Vercel.
-
-Last updated: Mon Jan 12 15:23:58 UTC 2026

--- a/nrsgirls-platform/README.md
+++ b/nrsgirls-platform/README.md
@@ -1,21 +1,54 @@
-NRS Girls Platform
+# NRSgirls Platform
 
-Overview
+Core platform scaffold for the NRSgirls streaming application. This directory contains drafted documentation, frontend and backend stubs, deployment manifests, scripts, and placeholder brand assets.
 
-This directory contains the initial scaffold for the nrsgirls-platform project: a modern web platform connecting DJs and performers while preserving performer privacy and legal safety. It includes drafted documentation, frontend and backend stubs, deployment manifests, scripts, and placeholder brand assets so contributors can iterate quickly.
+## Structure
 
-Structure
+```
+nrsgirls-platform/
+├── docs/               # Vision, team, technical spec, legal memo, business plan
+├── frontend/           # Next.js app — homepage, DJ portal, performer portal
+│   ├── pages/          # Next.js pages and API routes
+│   ├── styles/         # Global CSS
+│   ├── shared-components/  # Reusable UI components
+│   ├── dj-portal/      # DJ enrollment and dashboard (planned)
+│   ├── performer-portal/   # Performer profiles and privacy (planned)
+│   └── homepage/       # Landing page components
+├── backend/            # API, database, security, streaming stubs
+├── brand-assets/       # Logos, color schemes, style guide (placeholders)
+├── deployment/         # Docker and hosting configuration
+└── scripts/            # Setup, deploy, migrate, backup utilities
+```
 
-- docs/: Vision, team, technical specification, legal memo, and business plan.
-- frontend/: Homepage, DJ and performer portals, and shared components.
-- backend/: API endpoints, database schema, security scanning, and streaming integration notes.
-- brand-assets/: Placeholder directories for logos and color schemes with a style guide.
-- deployment/: Docker and hosting configuration and infrastructure notes.
-- scripts/: Setup and deployment automation.
+## Getting Started
 
-Tone: Professional — content is drafted to reflect the NRS Group of Fresno's formal, community-focused voice.
+```bash
+cd nrsgirls-platform/frontend
+yarn install
+cp .env.example .env.local
+yarn dev
+```
 
-Notes
+## Git Configuration
 
-- This scaffold uses placeholders for binary assets; add real images and logos into brand-assets/logos/.
-- No secrets are included. See .env.example for required environment variables.
+See the [Git Configuration Guide](../docs/best-practices/git-configuration.md) for recommended settings.
+
+The repo root includes:
+- `.gitattributes` — enforces LF line endings and binary file handling
+- `.editorconfig` — consistent indentation and whitespace across editors
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/setup.sh` | Initial project setup |
+| `scripts/lint-test.sh` | Run linting and tests |
+| `scripts/deploy.sh` | Deploy application |
+| `scripts/migrate.sh` | Run database migrations |
+| `scripts/backup-db.sh` | Backup database |
+
+## Notes
+
+- This scaffold uses placeholders for binary assets; add real images and logos into `brand-assets/logos/`.
+- No secrets are included. See `.env.example` for required environment variables.
+- Tone: Professional, reflecting the NRS Group of Fresno's formal, community-focused voice.

--- a/nrsgirls-platform/backend/api/README.md
+++ b/nrsgirls-platform/backend/api/README.md
@@ -1,10 +1,15 @@
-API
+# API
 
-REST API design and endpoint catalog will be developed here. Core routes:
-- /auth/* (signup, login, token refresh)
-- /djs/* (profile, uploads, stats)
-- /performers/* (profiles, privacy controls)
-- /mixes/* (upload processing, metadata, streaming links)
-- /moderation/* (queues, decisions)
+REST API design and endpoint catalog will be developed here.
 
-Authentication: JWT with role-based claims. Rate limiting and auditing required.
+## Core Routes
+
+- `/auth/*` — signup, login, token refresh
+- `/djs/*` — profile, uploads, stats
+- `/performers/*` — profiles, privacy controls
+- `/mixes/*` — upload processing, metadata, streaming links
+- `/moderation/*` — queues, decisions
+
+## Authentication
+
+JWT with role-based claims. Rate limiting and auditing required.

--- a/nrsgirls-platform/backend/database/README.md
+++ b/nrsgirls-platform/backend/database/README.md
@@ -1,10 +1,15 @@
-Database
+# Database
 
-High level schema notes:
-- users (id, role, email, hashed_password, created_at)
-- djs (user_id, display_name, bio, metadata)
-- performers (user_id, profile_name, privacy_settings, contact)
-- mixes (id, dj_id, title, duration, file_path, rights_metadata)
-- plays (mix_id, user_id, timestamp)
+High-level schema notes.
+
+## Tables
+
+| Table | Key Columns |
+|-------|-------------|
+| `users` | id, role, email, hashed_password, created_at |
+| `djs` | user_id, display_name, bio, metadata |
+| `performers` | user_id, profile_name, privacy_settings, contact |
+| `mixes` | id, dj_id, title, duration, file_path, rights_metadata |
+| `plays` | mix_id, user_id, timestamp |
 
 Migrations and schema SQL to be added in future tasks.

--- a/nrsgirls-platform/backend/security/README.md
+++ b/nrsgirls-platform/backend/security/README.md
@@ -1,9 +1,10 @@
-Security
+# Security
 
 Planned security measures:
-- File scanning for viruses and known-malware
+
+- File scanning for viruses and known malware
 - MP3 validation and format checks
 - Fingerprinting for duplicate detection
 - Content moderation pipelines with human review
 
-Privacy and data handling policies belong in docs/LEGAL_MEMO.md.
+Privacy and data handling policies belong in [`docs/LEGAL_MEMO.md`](../../docs/LEGAL_MEMO.md).

--- a/nrsgirls-platform/backend/streaming/README.md
+++ b/nrsgirls-platform/backend/streaming/README.md
@@ -1,6 +1,7 @@
-Streaming Integration
+# Streaming Integration
 
-Guidance for streaming:
+Guidance for streaming infrastructure.
+
 - Use object storage + CDN for public assets
 - Provide signed expiring URLs for private/controlled streams
 - Support HLS for adaptive streaming

--- a/nrsgirls-platform/brand-assets/color-schemes/README.md
+++ b/nrsgirls-platform/brand-assets/color-schemes/README.md
@@ -1,7 +1,12 @@
-Color Schemes — placeholders
+# Color Schemes
 
-Provide JSON or CSS variables describing brand colors. Example tokens:
-- --nrs-primary: #123456
-- --nrs-accent: #abcdef
+Provide JSON or CSS variables describing brand colors.
 
-Replace with approved palette.
+## Example Tokens
+
+```css
+--nrs-primary: #123456;
+--nrs-accent: #abcdef;
+```
+
+> **Status:** Placeholder. Replace with approved palette.

--- a/nrsgirls-platform/brand-assets/logos/README.md
+++ b/nrsgirls-platform/brand-assets/logos/README.md
@@ -1,8 +1,11 @@
-Logos — placeholders
+# Logos
 
-Drop official PNG/SVG logos into this directory. Filenames to use when adding assets:
-- logo-primary.png
-- logo-primary.svg
-- logo-mark.png
+Drop official PNG/SVG logos into this directory.
 
-Do not commit sensitive or proprietary files without authorization.
+## Expected Filenames
+
+- `logo-primary.png`
+- `logo-primary.svg`
+- `logo-mark.png`
+
+> **Status:** Placeholder. Do not commit sensitive or proprietary files without authorization.

--- a/nrsgirls-platform/brand-assets/style-guide.md
+++ b/nrsgirls-platform/brand-assets/style-guide.md
@@ -1,10 +1,12 @@
-Style Guide — NRS Girls (Placeholder)
+# Style Guide
 
-This document describes branding guidelines. Replace placeholders with approved assets.
+Branding guidelines for NRSgirls. Replace placeholders with approved assets.
 
-- Primary mark: placeholder/logo-primary.png
-- Color palette: See color-schemes/ (placeholders)
-- Typography: System fonts or specified web fonts
-- Usage: Clear space, minimum sizes, and color combinations
+## Brand Elements
 
-Store final images in brand-assets/logos/ and color-schemes/.
+- **Primary mark:** `logos/logo-primary.png`
+- **Color palette:** See [`color-schemes/`](color-schemes/README.md)
+- **Typography:** System fonts or specified web fonts
+- **Usage:** Clear space, minimum sizes, and color combinations
+
+Store final images in `logos/` and `color-schemes/`.

--- a/nrsgirls-platform/deployment/infrastructure-setup.md
+++ b/nrsgirls-platform/deployment/infrastructure-setup.md
@@ -1,5 +1,17 @@
-Infrastructure Setup — Notes
+# Infrastructure Setup
 
-This document outlines recommended infrastructure: containerized services, managed Postgres, S3-compatible storage, and a CDN for streaming. For frontend hosting, Vercel is recommended for static and serverless functions.
+Recommended infrastructure for the NRSgirls platform.
 
-Follow secure secret management and create separate staging and production environments.
+## Components
+
+- **Containerized services** — Docker for local development and deployment
+- **Managed PostgreSQL** — Supabase or Neon for production database
+- **S3-compatible storage** — Cloudflare R2 or AWS S3 for media uploads
+- **CDN** — Content delivery for streaming assets
+- **Frontend hosting** — Vercel for static pages and serverless functions
+
+## Best Practices
+
+- Use secure secret management (environment variables, never committed)
+- Create separate staging and production environments
+- See [Deployment Guide](../../docs/DEPLOYMENT.md) for detailed instructions

--- a/nrsgirls-platform/frontend/dj-portal/README.md
+++ b/nrsgirls-platform/frontend/dj-portal/README.md
@@ -1,8 +1,11 @@
-DJ Portal
+# DJ Portal
 
-Contains DJ enrollment flow, upload widgets, and dashboard implementation notes. Key components:
-- Signup / onboarding
-- Upload form with metadata and rights-check checklist
-- Dashboard: upload history, analytics, monetization settings
+DJ enrollment flow, upload widgets, and dashboard.
 
-TODO: Implement frontend pages and wire to backend API.
+## Key Components
+
+- **Signup / onboarding** — DJ registration and profile setup
+- **Upload form** — metadata entry and rights-check checklist
+- **Dashboard** — upload history, analytics, monetization settings
+
+> **Status:** Planned. Implement frontend pages and wire to backend API.

--- a/nrsgirls-platform/frontend/homepage/README.md
+++ b/nrsgirls-platform/frontend/homepage/README.md
@@ -1,10 +1,11 @@
-Homepage
+# Homepage
 
-This folder contains the landing page and public marketing content. Implement a split experience that surfaces DJ content and performer resources.
+Landing page and public marketing content. A split experience that surfaces DJ content and performer resources.
 
-Key elements:
-- Hero: DJ / Performer split call-to-action
-- Features: privacy controls, moderation, streaming quality
-- Community: events, local chapters, support
+## Key Elements
 
-See shared-components/ for reusable UI elements.
+- **Hero** — DJ / Performer split call-to-action
+- **Features** — privacy controls, moderation, streaming quality
+- **Community** — events, local chapters, support
+
+See [`shared-components/`](../shared-components/README.md) for reusable UI elements.

--- a/nrsgirls-platform/frontend/performer-portal/README.md
+++ b/nrsgirls-platform/frontend/performer-portal/README.md
@@ -1,8 +1,11 @@
-Performer Portal
+# Performer Portal
 
-Performer profiles and privacy controls. Key capabilities:
-- Create/claim profile
-- Choose visibility: anonymous/pseudonymous/identified
-- Manage claims and takedowns
+Performer profiles and privacy controls.
 
-TODO: Implement frontend pages and wire to backend API.
+## Key Capabilities
+
+- **Create/claim profile** — performer registration
+- **Choose visibility** — anonymous, pseudonymous, or identified
+- **Manage claims and takedowns** — content control tools
+
+> **Status:** Planned. Implement frontend pages and wire to backend API.

--- a/nrsgirls-platform/frontend/shared-components/README.md
+++ b/nrsgirls-platform/frontend/shared-components/README.md
@@ -1,5 +1,14 @@
-Shared UI Components
+# Shared UI Components
 
-Reusable elements: Header, Footer, ConsentModal, PrivacySettings, FileUploader, AnalyticsCard.
+Reusable React components shared across all portals.
 
-TODO: Implement components in the chosen framework (React/Vue/Next.js) and expose design tokens from brand-assets/style-guide.md.
+## Planned Components
+
+- `Header` — site-wide navigation
+- `Footer` — site-wide footer
+- `ConsentModal` — privacy consent dialog
+- `PrivacySettings` — user privacy controls
+- `FileUploader` — media upload widget
+- `AnalyticsCard` — dashboard analytics display
+
+> **Status:** Planned. Implement in React/Next.js and expose design tokens from [`brand-assets/style-guide.md`](../../brand-assets/style-guide.md).

--- a/nrsgirls-platform/scripts/build-frontend.sh
+++ b/nrsgirls-platform/scripts/build-frontend.sh
@@ -2,12 +2,7 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-# Try root-level frontend/nextjs first
-FRONTEND_DIR="$ROOT/frontend/nextjs"
-if [ ! -d "$FRONTEND_DIR" ]; then
-  # Fall back to platform frontend
-  FRONTEND_DIR="$ROOT/nrsgirls-platform/frontend"
-fi
+FRONTEND_DIR="$ROOT/nrsgirls-platform/frontend"
 
 if [ ! -d "$FRONTEND_DIR" ]; then
   echo "Frontend directory not found"
@@ -15,7 +10,7 @@ if [ ! -d "$FRONTEND_DIR" ]; then
 fi
 
 cd "$FRONTEND_DIR"
-if [ -f package.json ] && grep -q ""build"" package.json; then
+if [ -f package.json ] && grep -q '"build"' package.json; then
   if command -v yarn >/dev/null 2>&1; then
     yarn build
   else

--- a/nrsgirls-platform/scripts/lint-test.sh
+++ b/nrsgirls-platform/scripts/lint-test.sh
@@ -2,24 +2,13 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-# Root-level frontend/nextjs
-if [ -d "$ROOT/frontend/nextjs" ] && [ -f "$ROOT/frontend/nextjs/package.json" ]; then
-  cd "$ROOT/frontend/nextjs"
-  if grep -q ""lint"" package.json; then
-    if command -v yarn >/dev/null 2>&1; then yarn lint; else npm run lint; fi || true
-  fi
-  if grep -q ""test"" package.json; then
-    if command -v yarn >/dev/null 2>&1; then yarn test; else npm test; fi || true
-  fi
-fi
-
 # Platform frontend
 if [ -d "$ROOT/nrsgirls-platform/frontend" ] && [ -f "$ROOT/nrsgirls-platform/frontend/package.json" ]; then
   cd "$ROOT/nrsgirls-platform/frontend"
-  if grep -q ""lint"" package.json; then
+  if grep -q '"lint"' package.json; then
     if command -v yarn >/dev/null 2>&1; then yarn lint; else npm run lint; fi || true
   fi
-  if grep -q ""test"" package.json; then
+  if grep -q '"test"' package.json; then
     if command -v yarn >/dev/null 2>&1; then yarn test; else npm test; fi || true
   fi
 fi
@@ -27,10 +16,10 @@ fi
 # Platform backend
 if [ -d "$ROOT/nrsgirls-platform/backend" ] && [ -f "$ROOT/nrsgirls-platform/backend/package.json" ]; then
   cd "$ROOT/nrsgirls-platform/backend"
-  if grep -q ""lint"" package.json; then
+  if grep -q '"lint"' package.json; then
     if command -v yarn >/dev/null 2>&1; then yarn lint; else npm run lint; fi || true
   fi
-  if grep -q ""test"" package.json; then
+  if grep -q '"test"' package.json; then
     if command -v yarn >/dev/null 2>&1; then yarn test; else npm test; fi || true
   fi
 fi

--- a/nrsgirls-platform/scripts/setup.sh
+++ b/nrsgirls-platform/scripts/setup.sh
@@ -31,7 +31,5 @@ install_if_pkg() {
 # Install platform frontend/backend if they exist
 install_if_pkg nrsgirls-platform/frontend
 install_if_pkg nrsgirls-platform/backend
-# Install root-level frontend/nextjs
-install_if_pkg frontend/nextjs
 echo "Setup complete. Edit .env and run the services you need.
 "


### PR DESCRIPTION
- Add docs/best-practices/git-configuration.md with recommended Git settings for all contributors (line endings, merge strategy, aliases)
- Add .gitattributes for line-ending normalization and binary file handling
- Add .editorconfig for consistent editor behavior across the team
- Fix all references from non-existent frontend/nextjs/ to the actual path nrsgirls-platform/frontend/ (CI workflow, CLAUDE.md, scripts, VS Code tasks, Next.js 16 upgrade notes)
- Update root README.md with proper structure, Git configuration section, tech stack table, and documentation index
- Clean up all placeholder READMEs with proper markdown formatting (headings, tables, bold labels, status callouts)
- Expand .gitignore with comprehensive patterns (Prisma, Docker, editors)
- Remove stale dummy_commit.txt
- Update best-practices README to reference new Git configuration guide

https://claude.ai/code/session_01SqsZ7qJHzW511bJUuBoWoG

## Summary by Sourcery

Document Git and repo structure, enforce consistent tooling configs, and align paths and docs with the nrsgirls-platform/frontend layout.

Build:
- Add .gitattributes and .editorconfig to standardize line endings, diffs, and editor behavior across contributors.

CI:
- Update CI workflow to use nrsgirls-platform/frontend paths and Yarn lockfile for install/build steps.

Documentation:
- Add a Git configuration guide and link it from project READMEs and best-practices docs.
- Restructure and expand root and platform READMEs with project overview, structure, quick start, tech stack, and internal documentation index.
- Clarify and standardize placeholder READMEs across backend, frontend portals, brand assets, and deployment docs with headings, tables, and clearer descriptions.

Chores:
- Remove legacy references to frontend/nextjs throughout docs, scripts, CI, VS Code tasks, and deployment configs in favor of nrsgirls-platform/frontend.
- Simplify setup and build scripts to target the nrsgirls-platform frontend/backend only and drop support for the old frontend location.
- Expand .gitignore patterns and delete obsolete placeholder files.